### PR TITLE
Fix .gitmodules reference to junctions repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "junctions"]
 	path = junctions
-	url = https://github.com/ucb-bar/junctions.git
+	url = https://github.com/lowRISC/junctions.git
 [submodule "context-dependent-environments"]
 	path = context-dependent-environments
 	url = https://github.com/ucb-bar/context-dependent-environments.git


### PR DESCRIPTION
The junctions repo has been discontinued by ucb-bar, but lowRISC still has a copy.